### PR TITLE
Fix libcurl dependency in debian/control (should be libcurl3 instead of libcurl)

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -35,7 +35,7 @@ Package: libaws-s3fs0
 Architecture: any
 Pre-Depends: ${misc:Pre-Depends}, dpkg (>= 1.15.6)
 Depends: ${shlibs:Depends}, ${misc:Depends},
- libcurl (>= 7.20), libfuse2 (>= 2.8.4), libconfig8 (>= 1.3),
+ libcurl3 (>= 7.20), libfuse2 (>= 2.8.4), libconfig8 (>= 1.3),
  libxml2 (>= 2.7.0), libsqlite3-0 (>= 3.7.0)
 Description: FUSE module to mount an Amazon S3 bucket
  aws-s3fs is a transparent FUSE filesystem for reading and writing files


### PR DESCRIPTION
Without this fix installing libaws-s3fs reports a missing dependency on libcurl:

dpkg: dependency problems prevent configuration of libaws-s3fs0:
 libaws-s3fs0 depends on libcurl (>= 7.20); however:
  Package libcurl is not installed.

This happens on ubuntu-12.04.
